### PR TITLE
add center keyword to fixed X knockoff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Knockoffs"
 uuid = "878bf26d-0c49-448a-9df5-b057c815d613"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Benjamin Chu <benchu99@hotmail.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Knockoffs"
 uuid = "878bf26d-0c49-448a-9df5-b057c815d613"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Benjamin Chu <benchu99@hotmail.com> and contributors"]
 
 [deps]

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -28,7 +28,7 @@ computing its knockoff.
 2. "Powerful knockoffs via minimizing reconstructability" by Spector, Asher, and Lucas Janson (2020)
 3. "FANOK: Knockoffs in Linear Time" by Askari et al. (2020).
 """
-function fixed_knockoffs(X::Matrix{T}, method::Symbol; center::Bool=false, kwargs...) where T <: AbstractFloat
+function fixed_knockoffs(X::Matrix{T}, method::Union{Symbol, AbstractString}; center::Bool=false, kwargs...) where T <: AbstractFloat
     n, p = size(X)
     n ≥ 2p || error("fixed_knockoffs: currently only works for n ≥ 2p case! sorry!")
     # use column-normalized X 
@@ -52,5 +52,5 @@ function fixed_knockoffs(X::Matrix{T}, method::Symbol; center::Bool=false, kwarg
     C = Diagonal(sqrt.(γ)) * P'
     # compute knockoffs
     X̃ = X * (I - Σinv*D) + Ũ * C
-    return GaussianKnockoff(X, X̃, s, Symmetric(Σ), method, 1)
+    return GaussianKnockoff(X, X̃, s, Symmetric(Σ), Symbol(method), 1)
 end

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -1,5 +1,5 @@
 """
-    fixed_knockoffs(X::Matrix{T}; [method], [kwargs...])
+    fixed_knockoffs(X::Matrix{T}, method::Symbol; [center], [kwargs...])
 
 Creates fixed-X knockoffs. Internally, `X` will be automatically normalized before
 computing its knockoff. 
@@ -7,12 +7,15 @@ computing its knockoff.
 # Inputs
 + `X`: A column-normalized `n × p` numeric matrix, each row is a sample, and
     each column is covariate. We will internally normalized `X` if it is not. 
+
+# Optional inputs
 + `method`: Can be one of the following
     * `:mvr`: Minimum variance-based reconstructability knockoffs (alg 1 in ref 2)
     * `:maxent`: Maximum entropy knockoffs (alg 2 in ref 2)
     * `:equi`: Equi-distant knockoffs (eq 2.3 in ref 1), 
     * `:sdp`: SDP knockoffs (eq 2.4 in ref 1)
     * `:sdp_fast`: SDP knockoffs via coordiate descent (alg 2.2 in ref 3)
++ `center`: Whether to center the columns of `X` before normalizing, defaults to `false`.
 + `kwargs...`: Possible optional inputs to `method`, see [`solve_MVR`](@ref), 
     [`solve_max_entropy`](@ref), and [`solve_sdp_ccd`](@ref)
 
@@ -25,11 +28,11 @@ computing its knockoff.
 2. "Powerful knockoffs via minimizing reconstructability" by Spector, Asher, and Lucas Janson (2020)
 3. "FANOK: Knockoffs in Linear Time" by Askari et al. (2020).
 """
-function fixed_knockoffs(X::Matrix{T}, method::Symbol; kwargs...) where T <: AbstractFloat
+function fixed_knockoffs(X::Matrix{T}, method::Symbol; center::Bool=false, kwargs...) where T <: AbstractFloat
     n, p = size(X)
     n ≥ 2p || error("fixed_knockoffs: currently only works for n ≥ 2p case! sorry!")
     # use column-normalized X 
-    X = normalize_col(X)
+    X = normalize_col(X, center=center)
     # compute gram matrix using full svd
     U, σ, V = svd(X, full=true)
     Σ = V * Diagonal(σ)^2 * V'

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -434,19 +434,23 @@ end
 """
     normalize_col!(X::AbstractVecOrMat, [center=false])
 
-Normalize each column of `X` so they sum to 1. 
+Normalize each column of `X` to have unit Euclidean norm, optionally after centering.
 """
 function normalize_col!(X::AbstractVecOrMat; center::Bool=false)
     @inbounds for x in eachcol(X)
         μi = center ? mean(x) : zero(eltype(X))
-        xnorm = norm(x)
         @simd for i in eachindex(x)
-            x[i] = (x[i] - μi) / xnorm
+            x[i] -= μi
+        end
+        xnorm = norm(x)
+        iszero(xnorm) && error("normalize_col!: cannot normalize a zero-norm column.")
+        @simd for i in eachindex(x)
+            x[i] /= xnorm
         end
     end
     return X
 end
-normalize_col(X) = normalize_col!(copy(X))
+normalize_col(X; center::Bool=false) = normalize_col!(copy(X), center=center)
 
 function sample_DMC(q, Q; n=1)
     p = size(Q, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,17 @@ using ToeplitzMatrices
             @test dot(X[:, i], Xko[:, j]) ≈ dot(X[:, i], X[:, j])
         end
     end
+
+    # centering is keyword-controlled and preserves the fixed-X Gram conditions
+    n = 31
+    p = 10
+    X = randn(n, p) .+ randn(1, p)
+    centered = fixed_knockoffs(X, :equi; center=true)
+    @test all(isapprox.(vec(sum(centered.X; dims=1)), 0, atol=1e-10))
+    @test all(isapprox.(vec(sum(abs2, centered.X; dims=1)), 1, atol=1e-10))
+    @test all(isapprox.(centered.X' * centered.X, centered.Sigma, atol=1e-8))
+    @test all(isapprox.(centered.Xko' * centered.Xko, centered.Sigma, atol=1e-8))
+    @test all(isapprox.(centered.X' * centered.Xko, centered.Sigma - Diagonal(centered.s), atol=1e-8))
 end
 
 @testset "model X Guassian Knockoffs" begin


### PR DESCRIPTION
Example: 

```
n = 31
p = 10
X = randn(n, p) .+ randn(1, p)
fixed_knockoffs(X, "maxent"; center=true)
```
