### PR TITLE
Better python/R support for method var

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Knockoffs"
 uuid = "878bf26d-0c49-448a-9df5-b057c815d613"
-version = "3.1.3"
+version = "3.1.4"
 authors = ["Benjamin Chu <benchu99@hotmail.com> and contributors"]
 
 [deps]

--- a/src/fit_lasso.jl
+++ b/src/fit_lasso.jl
@@ -34,10 +34,12 @@ function fit_lasso(
     d::Distribution=Normal(),
     m::Number = 1,
     groups::Union{Nothing, AbstractVector{Int}} = nothing,
-    filter_method::Symbol = :knockoff_plus,
-    debias::Union{Nothing, Symbol} = nothing,
+    filter_method::Union{Symbol,String} = :knockoff_plus,
+    debias::Union{Nothing, Symbol, String} = nothing,
     kwargs..., # arguments for glmnetcv
     ) where T
+    filter_method = Symbol(filter_method)
+    !isnothing(debias) && (debias = Symbol(debias))
     ko = isnothing(groups) ? modelX_gaussian_knockoffs(X, method, m=m) : 
         modelX_gaussian_group_knockoffs(X, method, groups, m=m)
     return fit_lasso(y, ko, d=d,
@@ -53,10 +55,12 @@ function fit_lasso(
     d::Distribution=Normal(),
     m::Number = 1,
     groups::Union{Nothing, AbstractVector{Int}} = nothing,
-    filter_method::Symbol = :knockoff_plus,
-    debias::Union{Nothing, Symbol} = :ls,
+    filter_method::Union{Symbol,String} = :knockoff_plus,
+    debias::Union{Nothing, Symbol, String} = :ls,
     kwargs..., # arguments for glmnetcv
     ) where T
+    filter_method = Symbol(filter_method)
+    !isnothing(debias) && (debias = Symbol(debias))
     ko = isnothing(groups) ? modelX_gaussian_knockoffs(X, method, μ, Σ, m=m) : 
         modelX_gaussian_group_knockoffs(X, method, groups, μ, Σ; m=m)
     return fit_lasso(y, ko, d=d,
@@ -67,11 +71,13 @@ function fit_lasso(
     y::AbstractVecOrMat{T},
     ko::Knockoff;
     d::Distribution=Normal(),
-    filter_method::Symbol = :knockoff_plus, # `:knockoff` or `:knockoff_plus`
-    debias::Union{Nothing, Symbol} = nothing,
+    filter_method::Union{Symbol,String} = :knockoff_plus, # `:knockoff` or `:knockoff_plus`
+    debias::Union{Nothing, Symbol, String} = nothing,
     stringent::Bool = false,
     kwargs..., # arguments for glmnetcv
     ) where T <: AbstractFloat
+    filter_method = Symbol(filter_method)
+    !isnothing(debias) && (debias = Symbol(debias))
     typeof(y) <: AbstractMatrix && (y = vec(y))
     ytmp = d == Binomial() ? form_glmnet_logistic_y(y) : y
     X = ko.X
@@ -172,9 +178,10 @@ Return thresholded coefficients/intercept corresponding to q-value level `q`.
 function selected_coefficients(
     model::LassoKnockoffFilter{T},
     q::Real;
-    debias::Union{Nothing, Symbol}=model.debias,
+    debias::Union{Nothing, Symbol, String}=model.debias,
     kwargs...,
     ) where T
+    !isnothing(debias) && (debias = Symbol(debias))
     β_filtered = zeros(T, length(model.beta))
     selected_stats = select_variables(model, q)
     if hasproperty(model.ko, :groups)
@@ -234,9 +241,10 @@ function fit_marginal(
     d::Distribution=Normal(),
     m::Number = 1,
     groups::Union{Nothing, AbstractVector{Int}} = nothing,
-    filter_method::Symbol = :knockoff_plus,
+    filter_method::Union{Symbol,String} = :knockoff_plus,
     kwargs..., # arguments for glmnetcv
     ) where T
+    filter_method = Symbol(filter_method)
     ko = isnothing(groups) ? modelX_gaussian_knockoffs(X, method, m=m) : 
         modelX_gaussian_group_knockoffs(X, method, groups, m=m)
     return fit_marginal(y, ko, d=d,
@@ -247,8 +255,9 @@ function fit_marginal(
     y::AbstractVecOrMat{T},
     ko::Knockoff;
     d::Distribution=Normal(),
-    filter_method::Symbol = :knockoff_plus, # `:knockoff` or `:knockoff_plus`
+    filter_method::Union{Symbol,String} = :knockoff_plus, # `:knockoff` or `:knockoff_plus`
     ) where T <: AbstractFloat
+    filter_method = Symbol(filter_method)
     typeof(y) <: AbstractMatrix && (y = vec(y))
     X = ko.X
     X̃ = ko.Xko
@@ -311,6 +320,7 @@ function debias!(
     d::Distribution=Normal(),
     kwargs... # extra arguments for glmnetcv
     ) where T
+    method = Symbol(method)
     count(!iszero, β̂) == 0 && error("β̂ is all zeros! Nothing to debias!")
     zero_idx = β̂ .== 0
     if method == :lasso
@@ -349,6 +359,7 @@ function debias!(
     d::Distribution=Normal(),
     kwargs... # extra arguments for glmnetcv
     ) where T
+    method = Symbol(method)
     p = length(β̂)
     p == length(groups) || error("check vector length") # note GLMNet.jl does not include intercept in β̂
     count(!iszero, β̂) == 0 && error("β̂ is all zeros! Nothing to debias!")

--- a/src/group.jl
+++ b/src/group.jl
@@ -181,6 +181,7 @@ function modelX_gaussian_rep_group_knockoffs(
     kwargs... # extra arguments for solve_s_group
     ) where T
     size(X, 2) == length(groups)  || error("Dimensions of X and groups doesn't match")
+    method = Symbol(method)
 
     # compute group representatives
     group_reps = choose_group_reps(Symmetric(Σ), groups, threshold=rep_threshold)
@@ -355,13 +356,13 @@ function solve_s_group(
     # check for errors
     length(groups) == size(Σ, 1) || 
         error("Length of groups should be equal to dimension of Σ")
+    method = Symbol(method)
     max_group_size = countmap(groups) |> values |> collect |> maximum
     if max_group_size > 50 && method != :equi && !occursin("pca", string(method))
         @warn "Maximum group size is $max_group_size, optimization may be slow. " * 
             "Consider running `modelX_gaussian_rep_group_knockoffs` to speed up convergence."
         flush(stdout)
     end
-    method = Symbol(method)
     # Scale covariance to correlation matrix
     σs = sqrt.(diag(Σ))
     iscor = all(x -> x ≈ 1, σs)
@@ -706,6 +707,7 @@ function solve_group_block_update(
     niter = 100, # max number of cyclic block updates
     verbose::Bool = false,
     ) where T
+    method = Symbol(method)
     method ∈ [:sdp_block, :maxent_block, :mvr_block] ||
         error("Expected method to be :sdp_block, :maxent_block, or :mvr_block")
     p = size(Σ, 1)

--- a/src/ipad.jl
+++ b/src/ipad.jl
@@ -22,6 +22,7 @@ problem.
 + Ahn, S.C. and Horenstein, A.R., 2013. Eigenvalue ratio test for the number of factors. Econometrica, 81(3), pp.1203-1227.
 """
 function ipad(X::AbstractMatrix{T}; r_method = :er, m::Number = 1) where T
+    r_method = Symbol(r_method)
     n, p = size(X)
     # estimate r
     XXt = X * X'

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -2,7 +2,7 @@ function predict(
     model::LassoKnockoffFilter{T},
     xtest::AbstractMatrix{T},
     q::Real;
-    debias::Union{Nothing, Symbol}=model.debias,
+    debias::Union{Nothing, Symbol, String}=model.debias,
     kwargs...,
     ) where T
     β, a0 = selected_coefficients(model, q; debias=debias, kwargs...)
@@ -19,7 +19,7 @@ function predict(
     model::LassoKnockoffFilter{T},
     xtest::AbstractMatrix{T},
     qs::AbstractVector{<:Real};
-    debias::Union{Nothing, Symbol}=model.debias,
+    debias::Union{Nothing, Symbol, String}=model.debias,
     kwargs...,
     ) where T
     ŷs = Vector{T}[]

--- a/src/threshold.jl
+++ b/src/threshold.jl
@@ -18,6 +18,7 @@ Controlled Variable Selection" by Candes, Fan, Janson, and Lv (2018)
 """
 function threshold(w::AbstractVector{T}, q::Number,
     method=:knockoff_plus, rej_bounds::Int=10000) where T <: AbstractFloat
+    method = Symbol(method)
     0 ≤ q ≤ 1 || error("Target FDR should be between 0 and 1 but got $q")
     offset = method == :knockoff ? 0 : method == :knockoff_plus ? 1 :
         error("method should be :knockoff or :knockoff_plus but was $method.")
@@ -38,9 +39,10 @@ feature is the minimum target FDR at which that feature is selected.
 """
 function get_knockoff_qvalue(
     w::AbstractVector{T};
-    method::Symbol=:knockoff_plus,
+    method::Union{Symbol, String}=:knockoff_plus,
     rej_bounds::Int=10000,
     ) where T <: AbstractFloat
+    method = Symbol(method)
     rej_bounds > 0 || error("rej_bounds should be positive but got $rej_bounds")
     offset = method == :knockoff ? 0 : method == :knockoff_plus ? 1 :
         error("method should be :knockoff or :knockoff_plus but was $method.")
@@ -89,6 +91,7 @@ Chooses the multiple knockoff threshold `τ̂ > 0` by setting
 function mk_threshold(τ::Vector{T}, κ::Vector{Int}, m::Int, q::Number,
     method=:knockoff_plus, rej_bounds::Int=10000
     ) where T <: AbstractFloat
+    method = Symbol(method)
     0 ≤ q ≤ 1 || error("Target FDR should be between 0 and 1 but got $q")
     method == :knockoff_plus || error("Multiple knockoffs needs to use :knockoff_plus filtering method")
     length(τ) == length(κ) || error("Length of τ and κ should be the same")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,6 +219,59 @@ end
     end
 end
 
+@testset "Symbol and string inputs agree" begin
+    Random.seed!(2028)
+    n = 8
+    p = 2
+    Σ = [1.0 0.2; 0.2 1.0]
+    μ = zeros(p)
+    X = randn(n, p)
+    groups = collect(1:p)
+
+    # Use :equi to keep the test fast while still exercising method conversion.
+    Random.seed!(1)
+    ko_symbol = modelX_gaussian_knockoffs(X, :equi, μ, Σ)
+    Random.seed!(1)
+    ko_string = modelX_gaussian_knockoffs(X, "equi", μ, Σ)
+    @test ko_symbol.method == ko_string.method == :equi
+    @test ko_symbol.s ≈ ko_string.s
+    @test ko_symbol.Xko ≈ ko_string.Xko
+
+    Random.seed!(2)
+    group_symbol = modelX_gaussian_group_knockoffs(X, :equi, groups, μ, Σ)
+    Random.seed!(2)
+    group_string = modelX_gaussian_group_knockoffs(X, "equi", groups, μ, Σ)
+    @test group_symbol.method == group_string.method == :equi
+    @test group_symbol.S ≈ group_string.S
+    @test group_symbol.Xko ≈ group_string.Xko
+
+    Random.seed!(3)
+    rep_symbol = modelX_gaussian_rep_group_knockoffs(X, :equi, groups, μ, Σ)
+    Random.seed!(3)
+    rep_string = modelX_gaussian_rep_group_knockoffs(X, "equi", groups, μ, Σ)
+    @test rep_symbol.method == rep_string.method == :equi
+    @test rep_symbol.S ≈ rep_string.S
+    @test rep_symbol.Xko ≈ rep_string.Xko
+
+    w = [0.1, 1.9, 1.3, 1.8, 0.8, -0.7, -0.1]
+    @test threshold(w, 0.2, :knockoff) == threshold(w, 0.2, "knockoff")
+    @test get_knockoff_qvalue(w; method=:knockoff_plus) ==
+        get_knockoff_qvalue(w; method="knockoff_plus")
+
+    τ = [1.0, 0.4, 0.8, 0.3]
+    κ = [0, 1, 0, 2]
+    @test mk_threshold(τ, κ, 2, 0.2, :knockoff_plus) ==
+        mk_threshold(τ, κ, 2, 0.2, "knockoff_plus")
+
+    Random.seed!(4)
+    ipad_symbol = ipad(X; r_method=:er)
+    Random.seed!(4)
+    ipad_string = ipad(X; r_method="er")
+    @test ipad_symbol.r_method == ipad_string.r_method == :er
+    @test ipad_symbol.r == ipad_string.r
+    @test ipad_symbol.Xko ≈ ipad_string.Xko
+end
+
 @testset "MK_statistics" begin
     # single knockoffs
     beta = [1.0, 0.2, -0.3, 0.8, -0.1, 0.5]


### PR DESCRIPTION
## Summary

This PR makes Python/R-friendly string inputs behave the same as Julia `Symbol` inputs for user-facing symbolic options.

## Changes

- Convert `method` to `Symbol` in `modelX_gaussian_rep_group_knockoffs`, fixing the `GaussianRepGroupKnockoff(..., ::String, ...)` MethodError reported by Python users.
- Normalize string-valued symbolic options in related user-facing helpers, including `ipad`, threshold/q-value helpers, lasso/marginal filter options, prediction debiasing, and group solver helpers.
- Add a focused regression test that checks symbol/string parity on small inputs.
- Bump package version to `3.1.4`.

## Validation

- Ran the focused `"Symbol and string inputs agree"` test block locally: 15 passed.
- Smoke-tested the Python wrapper via `python-jl`: both `modelX_gaussian_group_knockoffs(..., "equi", ...)` and `modelX_gaussian_rep_group_knockoffs(..., "equi", ...)` returned `(40, 10)` knockoff matrices.